### PR TITLE
feat: Add backend support for map drawing tools

### DIFF
--- a/src/drawable.py
+++ b/src/drawable.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass, field
+from typing import Optional
+from .map_object import MapObject
+
+@dataclass
+class Drawable(MapObject):
+    """A base class for objects that can be drawn on the map, extending MapObject."""
+    stroke_color: str = "#000000"  # Default to black
+    stroke_width: int = 2
+    opacity: float = 1.0
+
+    def to_dict(self):
+        """Returns a serializable dictionary representation, including drawable properties."""
+        data = super().to_dict()
+        data.update({
+            'stroke_color': self.stroke_color,
+            'stroke_width': self.stroke_width,
+            'opacity': self.opacity
+        })
+        return data
+
+    @classmethod
+    def from_dict(cls, data):
+        """Creates a Drawable object from a dictionary."""
+        # This creates an instance of the class that calls this method (e.g., ShapeObject)
+        obj = super().from_dict(data)
+        obj.stroke_color = data.get('stroke_color', "#000000")
+        obj.stroke_width = data.get('stroke_width', 2)
+        obj.opacity = data.get('opacity', 1.0)
+        return obj

--- a/src/group.py
+++ b/src/group.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass, field
+from typing import List
+from .map_object import MapObject
+
+@dataclass
+class Group(MapObject):
+    """Represents a group of map objects, allowing them to be manipulated as a single unit."""
+    object_ids: List[str] = field(default_factory=list)
+
+    def to_dict(self):
+        """Returns a serializable dictionary representation, including the list of object IDs."""
+        data = super().to_dict()
+        data.update({
+            'object_ids': self.object_ids
+        })
+        # Override object_type to be specific
+        data['object_type'] = self.__class__.__name__
+        return data
+
+    @classmethod
+    def from_dict(cls, data):
+        """Creates a Group object from a dictionary."""
+        # This creates an instance of Group
+        obj = super().from_dict(data)
+        obj.object_ids = data.get('object_ids', [])
+        return obj

--- a/src/map.py
+++ b/src/map.py
@@ -3,6 +3,9 @@ from typing import List, Optional
 from enum import Enum, auto
 from .map_object import MapObject
 from .token import Token
+from .shape import Shape
+from .group import Group
+from .path import Path
 
 class GridType(Enum):
     SQUARE = auto()
@@ -73,6 +76,12 @@ class Map:
             new_obj = None
             if obj_type == 'Token':
                 new_obj = Token.from_dict(obj_data)
+            elif obj_type == 'Shape':
+                new_obj = Shape.from_dict(obj_data)
+            elif obj_type == 'Group':
+                new_obj = Group.from_dict(obj_data)
+            elif obj_type == 'Path':
+                new_obj = Path.from_dict(obj_data)
             elif obj_type == 'MapObject':
                 new_obj = MapObject.from_dict(obj_data)
             else:

--- a/src/map_manager.py
+++ b/src/map_manager.py
@@ -1,5 +1,6 @@
 from .map import Map, GridType
 from .map_object import MapObject
+from .group import Group
 
 class MapManager:
     """Manages all game maps and the objects on them."""
@@ -61,6 +62,23 @@ class MapManager:
         if not obj_to_move:
             raise ValueError(f"Object '{object_id}' not found on map '{map_name}'.")
 
+        # Calculate the change in position
+        dx = new_x - obj_to_move.x
+        dy = new_y - obj_to_move.y
+
+        # If the object is a group, move all its members by the same delta
+        if isinstance(obj_to_move, Group):
+            print(f"Moving group {obj_to_move.id}. Propagating move to {len(obj_to_move.object_ids)} members.")
+            for member_id in obj_to_move.object_ids:
+                member_obj = game_map.get_object(member_id)
+                if member_obj:
+                    member_obj.x += dx
+                    member_obj.y += dy
+                    print(f"  - Moved member {member_id} to ({member_obj.x}, {member_obj.y}).")
+                else:
+                    print(f"  - Warning: Member object with ID '{member_id}' not found.")
+
+        # Move the primary object (or the group object itself)
         obj_to_move.x = new_x
         obj_to_move.y = new_y
         print(f"Moved object {object_id} to ({new_x}, {new_y}) on map '{map_name}'.")

--- a/src/path.py
+++ b/src/path.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass, field
+from typing import List, Tuple
+from .drawable import Drawable
+
+@dataclass
+class Path(Drawable):
+    """Represents a freehand path or line on the map."""
+    points: List[Tuple[int, int]] = field(default_factory=list)
+
+    def to_dict(self):
+        """Returns a serializable dictionary representation, including the path's points."""
+        data = super().to_dict()
+        data.update({
+            'points': self.points
+        })
+        # Override object_type to be specific
+        data['object_type'] = self.__class__.__name__
+        return data
+
+    @classmethod
+    def from_dict(cls, data):
+        """Creates a Path object from a dictionary."""
+        obj = super().from_dict(data)
+        # The points are stored as a list of lists in JSON, so convert them back to tuples
+        obj.points = [tuple(p) for p in data.get('points', [])]
+        return obj

--- a/src/shape.py
+++ b/src/shape.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Optional
+from .drawable import Drawable
+
+class ShapeType(Enum):
+    CIRCLE = auto()
+    SQUARE = auto()
+    TRIANGLE = auto()
+    HEXAGON = auto()
+
+@dataclass
+class Shape(Drawable):
+    """Represents a geometric shape that can be placed on the map."""
+    shape_type: ShapeType = ShapeType.CIRCLE
+    fill_color: Optional[str] = None  # e.g., "#FF0000" for red fill
+
+    def to_dict(self):
+        """Returns a serializable dictionary representation, including shape properties."""
+        data = super().to_dict()
+        data.update({
+            'shape_type': self.shape_type.name,
+            'fill_color': self.fill_color
+        })
+        # Override object_type to be more specific
+        data['object_type'] = self.__class__.__name__
+        return data
+
+    @classmethod
+    def from_dict(cls, data):
+        """Creates a Shape object from a dictionary."""
+        obj = super().from_dict(data)
+
+        shape_type_name = data.get('shape_type', 'CIRCLE')
+        try:
+            obj.shape_type = ShapeType[shape_type_name]
+        except KeyError:
+            print(f"Warning: Unknown shape type '{shape_type_name}'. Defaulting to CIRCLE.")
+            obj.shape_type = ShapeType.CIRCLE
+
+        obj.fill_color = data.get('fill_color')
+        return obj

--- a/tests/test_drawing.py
+++ b/tests/test_drawing.py
@@ -1,0 +1,105 @@
+import unittest
+from src.map import Map
+from src.shape import Shape, ShapeType
+from src.path import Path
+from src.group import Group
+from src.map_manager import MapManager
+
+class TestDrawing(unittest.TestCase):
+
+    def test_shape_serialization(self):
+        """Tests that a Shape object can be serialized and deserialized correctly."""
+        print("Running test: test_shape_serialization")
+        shape = Shape(x=10, y=20, layer=1, shape_type=ShapeType.SQUARE, fill_color="#FF0000", opacity=0.5)
+        map_obj = Map(name="test_map", width=100, height=100, objects=[shape])
+
+        # Serialize
+        map_dict = map_obj.to_dict()
+
+        # Deserialize
+        new_map = Map.from_dict(map_dict)
+        self.assertEqual(len(new_map.objects), 1)
+        new_shape = new_map.objects[0]
+
+        self.assertIsInstance(new_shape, Shape)
+        self.assertEqual(new_shape.x, 10)
+        self.assertEqual(new_shape.y, 20)
+        self.assertEqual(new_shape.shape_type, ShapeType.SQUARE)
+        self.assertEqual(new_shape.fill_color, "#FF0000")
+        self.assertEqual(new_shape.opacity, 0.5)
+        self.assertEqual(new_shape.stroke_color, "#000000") # Check default value
+
+    def test_path_serialization(self):
+        """Tests that a Path object can be serialized and deserialized correctly."""
+        print("Running test: test_path_serialization")
+        points = [(0, 0), (10, 10), (20, 5)]
+        path = Path(x=5, y=5, layer=2, points=points, stroke_width=3)
+        map_obj = Map(name="test_map", width=100, height=100, objects=[path])
+
+        # Serialize
+        map_dict = map_obj.to_dict()
+
+        # Deserialize
+        new_map = Map.from_dict(map_dict)
+        self.assertEqual(len(new_map.objects), 1)
+        new_path = new_map.objects[0]
+
+        self.assertIsInstance(new_path, Path)
+        self.assertEqual(new_path.x, 5)
+        self.assertEqual(new_path.y, 5)
+        self.assertEqual(new_path.points, points)
+        self.assertEqual(new_path.stroke_width, 3)
+
+    def test_group_serialization(self):
+        """Tests that a Group object can be serialized and deserialized correctly."""
+        print("Running test: test_group_serialization")
+        group = Group(x=0, y=0, layer=0, object_ids=["id1", "id2"])
+        map_obj = Map(name="test_map", width=100, height=100, objects=[group])
+
+        # Serialize
+        map_dict = map_obj.to_dict()
+
+        # Deserialize
+        new_map = Map.from_dict(map_dict)
+        self.assertEqual(len(new_map.objects), 1)
+        new_group = new_map.objects[0]
+
+        self.assertIsInstance(new_group, Group)
+        self.assertEqual(new_group.object_ids, ["id1", "id2"])
+
+    def test_group_movement(self):
+        """Tests that moving a group also moves all its member objects."""
+        print("Running test: test_group_movement")
+        map_manager = MapManager()
+        map_manager.create_map("group_test_map", 100, 100)
+
+        # Create objects
+        shape1 = Shape(x=10, y=10, layer=1)
+        shape2 = Shape(x=20, y=20, layer=1)
+
+        # Create a group containing the shapes
+        # The group's own x/y can be an anchor, let's say at the average position
+        group = Group(x=15, y=15, layer=0, object_ids=[shape1.id, shape2.id])
+
+        # Add objects to the map
+        map_manager.add_object_to_map("group_test_map", shape1)
+        map_manager.add_object_to_map("group_test_map", shape2)
+        map_manager.add_object_to_map("group_test_map", group)
+
+        # Move the group
+        map_manager.move_object("group_test_map", group.id, 25, 35) # dx=10, dy=20
+
+        # Verify new positions
+        self.assertEqual(group.x, 25)
+        self.assertEqual(group.y, 35)
+
+        # shape1 started at (10, 10), should move to (10+10, 10+20) = (20, 30)
+        self.assertEqual(shape1.x, 20)
+        self.assertEqual(shape1.y, 30)
+
+        # shape2 started at (20, 20), should move to (20+10, 20+20) = (30, 40)
+        self.assertEqual(shape2.x, 30)
+        self.assertEqual(shape2.y, 40)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces the backend data models and logic required to support drawing and annotations on maps.

The new implementation is designed to be extensible and provides the foundational support for a UI to build upon.

The following classes have been added:
- `src/drawable.py`: A new base class `Drawable` which inherits from `MapObject` and adds common visual attributes like `stroke_color`, `stroke_width`, and `opacity`.
- `src/shape.py`: A `Shape` class for creating geometric shapes. It includes an enum for the shape type and an optional `fill_color`.
- `src/path.py`: A `Path` class for representing freehand drawings by storing a list of points.
- `src/group.py`: A `Group` class that can contain a list of other object IDs, allowing them to be manipulated as a single entity.

The following existing classes have been modified:
- `src/map.py`: The `from_dict` factory method has been updated to recognize and deserialize the new `Shape`, `Path`, and `Group` objects.
- `src/map_manager.py`: The `move_object` method now checks if an object is a `Group` and, if so, propagates the movement to all of its member objects.

A new test file `tests/test_drawing.py` has been added to ensure that all new objects can be serialized and deserialized correctly and that the group movement logic is functioning as expected.