### PR TITLE
feat: Add Pygame-based GUI for the VTT

### DIFF
--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -37,7 +37,7 @@ class App:
 
         info_panel_rect = pygame.Rect(10, self.height - 160, 300, 150)
         info_panel = pygame_gui.elements.UIPanel(relative_rect=info_panel_rect,
-                                                  starting_layer_height=1,
+                                                  starting_height=1,
                                                   manager=self.ui_manager)
 
         self.info_text_box = pygame_gui.elements.UITextBox(html_text="No object selected.",
@@ -47,7 +47,7 @@ class App:
 
         char_panel_rect = pygame.Rect(self.width - 210, 60, 200, 300)
         char_panel = pygame_gui.elements.UIPanel(relative_rect=char_panel_rect,
-                                                  starting_layer_height=1,
+                                                  starting_height=1,
                                                   manager=self.ui_manager)
 
         self.char_list = pygame_gui.elements.UISelectionList(relative_rect=pygame.Rect(0, 0, 180, 200),
@@ -62,7 +62,7 @@ class App:
 
         init_panel_rect = pygame.Rect(self.width - 210, 370, 200, 300)
         init_panel = pygame_gui.elements.UIPanel(relative_rect=init_panel_rect,
-                                                 starting_layer_height=1,
+                                                 starting_height=1,
                                                  manager=self.ui_manager)
 
         self.init_list = pygame_gui.elements.UISelectionList(relative_rect=pygame.Rect(0, 0, 180, 200),


### PR DESCRIPTION
This commit introduces a new graphical user interface for the virtual tabletop application, built using Pygame and pygame-gui.

The GUI provides a visual way to interact with the VTT engine and includes the following features:
- A map view that renders square and hexagonal grids.
- The ability to view, select, and move objects on the map.
- A character panel for listing and creating characters.
- An initiative tracker panel for managing combat order.

The GUI can be launched by running the application with the `gui` argument: `python main.py gui`

This commit also includes fixes to the existing test suite to ensure compatibility with the new changes, and fixes for Pygame initialization bugs.