### PR TITLE
feat: Add Pygame-based GUI for the VTT

### DIFF
--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -186,12 +186,11 @@ class App:
         """Updates the character list from the engine."""
         em = self.engine.get_entity_manager()
         char_items = []
-        for entity_id, entity in em.entities.items():
-            if entity.entity_type == "character":
-                name = entity.attributes.get('name', 'Unnamed')
-                hp = entity.attributes.get('hp', 'N/A')
-                display_text = f"{name} (HP: {hp})"
-                char_items.append((display_text, entity_id))
+        for entity in em.list_entities(entity_type="character"):
+            name = entity.attributes.get('name', 'Unnamed')
+            hp = entity.attributes.get('hp', 'N/A')
+            display_text = f"{name} (HP: {hp})"
+            char_items.append((display_text, entity.id))
 
         self.char_list.set_item_list(char_items)
 


### PR DESCRIPTION
This commit introduces a new graphical user interface for the virtual tabletop application, built using Pygame and pygame-gui.

The GUI provides a visual way to interact with the VTT engine and includes the following features:
- A map view that renders square and hexagonal grids.
- The ability to view, select, and move objects on the map.
- A character panel for listing and creating characters.
- An initiative tracker panel for managing combat order.

The GUI can be launched by running the application with the `gui` argument: `python main.py gui`

This commit also includes fixes to the existing test suite and several bug fixes related to Pygame initialization and engine API usage. The MapManager now correctly supports the concept of an "active map".